### PR TITLE
Fix deployment issues for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,21 @@ script:
   - export ELASTIC_BEANSTALK_LABEL=$TRAVIS_COMMIT
   - export ELASTIC_BEANSTALK_DESCRIPTION=$TRAVIS_COMMIT_MESSAGE
 deploy:
-  provider: elasticbeanstalk
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  region: "ap-southeast-1"
-  app: "isomer-redirection"
-  env: "redirection-$TRAVIS_BRANCH"
-  bucket_name: "redirection-$TRAVIS_BRANCH"
-  on:
-    branch: master
-deploy:
-  provider: elasticbeanstalk
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  region: "ap-southeast-1"
-  app: "isomer-redirection"
-  env: "redirection-$TRAVIS_BRANCH"
-  bucket_name: "redirection-$TRAVIS_BRANCH"
-  on:
-    branch: staging
+  - provider: elasticbeanstalk
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: "ap-southeast-1"
+    app: "isomer-redirection"
+    env: "redirection-$TRAVIS_BRANCH"
+    bucket_name: "redirection-$TRAVIS_BRANCH"
+    on:
+      branch: master
+  - provider: elasticbeanstalk
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: "ap-southeast-1"
+    app: "isomer-redirection"
+    env: "redirection-$TRAVIS_BRANCH"
+    bucket_name: "redirection-$TRAVIS_BRANCH"
+    on:
+      branch: staging


### PR DESCRIPTION
### Overview
The existing .travis.yml config only allows deployments to the staging branch. This is because there are two deploy blocks - and as such, TravisCI only accepts one block (the last block in the file).

### Fix
The fix is to set the two deployment configurations as an array in the deploy block.