### PR TITLE
Set up default server for port 443

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -75,4 +75,11 @@ http {
         listen  80 default_server;
         return 301 https://www.$host$request_uri;
     }
+
+    # Adding a default_server config ensures that all requests on port 443 that do not match existing server_name blocks
+    # will go to the following server directive:
+    server {
+        listen  443 default_server;
+        return  444;
+    }
 }


### PR DESCRIPTION
### Overview

Currently, if an HTTPS request comes to the redirection server, and the hostname of the request does not match any server directive blocks, the redirection server returns with the first server directive for port 443. 

### Fix

Add a default server block for port 443 that returns with an NGINX status code of [444](https://httpstatuses.com/444). 