### PR TITLE
Add wait_until_deploy and fix typo for redirection of MLAW websites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ deploy:
     app: "isomer-redirection"
     env: "redirection-$TRAVIS_BRANCH"
     bucket_name: "redirection-$TRAVIS_BRANCH"
+    wait_until_deployed: true
     on:
       branch: master
   - provider: elasticbeanstalk
@@ -24,5 +25,6 @@ deploy:
     app: "isomer-redirection"
     env: "redirection-$TRAVIS_BRANCH"
     bucket_name: "redirection-$TRAVIS_BRANCH"
+    wait_until_deployed: true
     on:
       branch: staging

--- a/domain_redirects.conf
+++ b/domain_redirects.conf
@@ -40,10 +40,10 @@ server {
 
 server {
         server_name     cmc.gov.sg *.cmc.gov.sg;
-        return 301 https://cmc.mlaw.gov.sg
+        return 301 https://cmc.mlaw.gov.sg;
 }
 
 server {
         server_name     lab.gov.sg *.lab.gov.sg;
-        return 301 https://lab.mlaw.gov.sg
+        return 301 https://lab.mlaw.gov.sg;
 }


### PR DESCRIPTION
Added a `wait_until_deploy: true` option in the `travis.yml` file 
Added `lab.gov.sg` and `cmc.gov.sg` to our redirection