### PR TITLE
ewn.sg -> ewn.gov.sg

### DIFF
--- a/domain_redirects.conf
+++ b/domain_redirects.conf
@@ -72,3 +72,8 @@ server {
         server_name     sgtogether.gov.sg *.sgtogether.gov.sg;
         return 301 https://www.singaporetogether.gov.sg;
 }
+
+server {
+        server_name     engineerwhatsnext.sg *.engineerwhatsnext.sg;
+        return 301 https://www.engineerwhatsnext.gov.sg;
+}

--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -200,8 +200,8 @@ server {
 server {
     listen         443 ssl http2;
     server_name   engineerwhatsnext.gov.sg;
-    ssl_certificate /ssl/engineerwhatsnext.gov.sg.crt; 
-    ssl_certificate_key /ssl/engineerwhatsnext.gov.sg.key;
+    ssl_certificate /ssl/www.engineerwhatsnext.gov.sg.crt; 
+    ssl_certificate_key /ssl/www.engineerwhatsnext.gov.sg.key;
     return         301 https://www.engineerwhatsnext.gov.sg$request_uri;
 }
 

--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -199,10 +199,10 @@ server {
 
 server {
     listen         443 ssl http2;
-    server_name   engineerwhatsnext.sg;
-    ssl_certificate /ssl/engineerwhatsnext.sg.crt; 
-    ssl_certificate_key /ssl/engineerwhatsnext.sg.key;
-    return         301 https://www.engineerwhatsnext.sg$request_uri;
+    server_name   engineerwhatsnext.gov.sg;
+    ssl_certificate /ssl/engineerwhatsnext.gov.sg.crt; 
+    ssl_certificate_key /ssl/engineerwhatsnext.gov.sg.key;
+    return         301 https://www.engineerwhatsnext.gov.sg$request_uri;
 }
 
 server {


### PR DESCRIPTION
On request, make engineerwhatsnext.gov.sg the main domain,
and redirect all .sg requests to it