### PR TITLE
Add NDP and IOHA redirects

### DIFF
--- a/domain_redirects.conf
+++ b/domain_redirects.conf
@@ -92,3 +92,8 @@ server {
         server_name     ndp.org.sg *.ndp.org.sg;
         return 301 https://www.ndp.gov.sg;
 }
+
+server {
+        server_name     ioha2020.sg *.ioha2020.sg;
+        return 301 https://www.ioha2021.gov.sg;
+}

--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -351,14 +351,6 @@ server {
       return         301 https://www.cpro.gov.sg$request_uri;
 }
 
-server {
-      listen         443 ssl http2;
-      server_name   cpro.gov.sg;
-      ssl_certificate /ssl/cpro.gov.sg.crt; 
-      ssl_certificate_key /ssl/cpro.gov.sg.key;
-      return         301 https://www.cpro.gov.sg$request_uri;
-}
-
 
 server {
     listen          443 ssl http2;

--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -336,23 +336,6 @@ server {
 }
 
 server {
-      listen         443 ssl http2;
-      server_name   cpro.gov.sg;
-      ssl_certificate /ssl/cpro.gov.sg.crt; 
-      ssl_certificate_key /ssl/cpro.gov.sg.key;
-      return         301 https://www.cpro.gov.sg$request_uri;
-}
-
-server {
-      listen         443 ssl http2;
-      server_name   cpro.gov.sg;
-      ssl_certificate /ssl/cpro.gov.sg.crt; 
-      ssl_certificate_key /ssl/cpro.gov.sg.key;
-      return         301 https://www.cpro.gov.sg$request_uri;
-}
-
-
-server {
     listen          443 ssl http2;
     server_name     ndp.org.sg www.ndp.org.sg;
     ssl_certificate /ssl/www.ndp.org.sg.crt;

--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -335,3 +335,45 @@ server {
       return         301 https://www.cpro.gov.sg$request_uri;
 }
 
+server {
+      listen         443 ssl http2;
+      server_name   cpro.gov.sg;
+      ssl_certificate /ssl/cpro.gov.sg.crt; 
+      ssl_certificate_key /ssl/cpro.gov.sg.key;
+      return         301 https://www.cpro.gov.sg$request_uri;
+}
+
+server {
+      listen         443 ssl http2;
+      server_name   cpro.gov.sg;
+      ssl_certificate /ssl/cpro.gov.sg.crt; 
+      ssl_certificate_key /ssl/cpro.gov.sg.key;
+      return         301 https://www.cpro.gov.sg$request_uri;
+}
+
+server {
+      listen         443 ssl http2;
+      server_name   cpro.gov.sg;
+      ssl_certificate /ssl/cpro.gov.sg.crt; 
+      ssl_certificate_key /ssl/cpro.gov.sg.key;
+      return         301 https://www.cpro.gov.sg$request_uri;
+}
+
+
+server {
+    listen          443 ssl http2;
+    server_name     ndp.org.sg www.ndp.org.sg;
+    ssl_certificate /ssl/www.ndp.org.sg.crt;
+    ssl_certificate_key     /ssl/www.ndp.org.sg.key;
+    return          301 https://www.ndp.gov.sg$request_uri;
+}
+
+server {
+    listen          443 ssl http2;
+    server_name     ndp.gov.sg;
+    ssl_certificate /ssl/www.ndp.gov.sg.crt;
+    ssl_certificate_key     /ssl/www.ndp.gov.sg.key;
+    return          301 https://www.ndp.gov.sg$request_uri;
+}
+
+

--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -112,10 +112,10 @@ server {
 
 server {
     listen          443 ssl http2;
-    server_name     ioha2020.sg;
+    server_name     ioha2020.sg www.ioha2020.sg;
     ssl_certificate /ssl/ioha2020.sg.crt;
     ssl_certificate_key     /ssl/ioha2020.sg.key;
-    return          301 https://www.ioha2020.sg$request_uri;
+    return          301 https://www.ioha2021.gov.sg$request_uri;
 }
 
 server {
@@ -376,4 +376,11 @@ server {
     return          301 https://www.ndp.gov.sg$request_uri;
 }
 
+server {
+    listen          443 ssl http2;
+    server_name     ioha2021.gov.sg;
+    ssl_certificate /ssl/www.ioha2021.gov.sg.crt;
+    ssl_certificate_key     /ssl/www.ioha2021.gov.sg.key;
+    return          301 https://www.ioha2021.gov.sg$request_uri;
+}
 


### PR DESCRIPTION
This PR accomplishes the following:
- add HTTPS redirects for NDP
- add redirects from NDP.ORG.SG to NDP.GOV.SG
- adds HTTPS redirects for IOHA2021
- modify existing HTTPS redirects for IOHA2020
- adds HTTP redirects for IOHA2020