### PR TITLE
fix: undo ioha2020 fix

### DIFF
--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -112,10 +112,10 @@ server {
 
 server {
     listen          443 ssl http2;
-    server_name     ioha2020.sg www.ioha2020.sg;
+    server_name     ioha2020.sg;
     ssl_certificate /ssl/ioha2020.sg.crt;
     ssl_certificate_key     /ssl/ioha2020.sg.key;
-    return          301 https://www.ioha2021.gov.sg$request_uri;
+    return          301 https://www.ioha2020.sg$request_uri;
 }
 
 server {


### PR DESCRIPTION
This PR undoes the fix for `ioha2020.sg` redirection since the IOHA team is not ready and has not performed the necessary DNS changes.