### PR TITLE
http-only redirects for SupplyAlly

### DIFF
--- a/domain_redirects.conf
+++ b/domain_redirects.conf
@@ -97,3 +97,8 @@ server {
         server_name     ioha2020.sg *.ioha2020.sg;
         return 301 https://www.ioha2021.gov.sg;
 }
+
+server {
+        server_name     sally.gov.sg *.sally.gov.sg supplyally.gov.sg;
+        return 301 https://www.supplyally.gov.sg;
+}


### PR DESCRIPTION
SupplyAlly have opted for KeyCDN's LetsEncrypt SSL cert, which limits us to 
offering http redirects only. Rely on the browser to find the correct URL when
the user types the domain into the browser, and redirect http requests to
https://www.supplyally.gov.sg