### PR TITLE
fix: allow https redirection from www.ioha2020.sg to www.ioha2021.gov.sg

### DIFF
--- a/https_www_redirects.conf
+++ b/https_www_redirects.conf
@@ -398,7 +398,7 @@ server {
 server {
     listen          443 ssl http2;
     listen          [::]:443 ssl http2;
-    server_name     ioha2021.gov.sg;
+    server_name     ioha2021.gov.sg www.ioha2020.sg;
     ssl_certificate /ssl/www.ioha2021.gov.sg.crt;
     ssl_certificate_key     /ssl/www.ioha2021.gov.sg.key;
     return          301 https://www.ioha2021.gov.sg$request_uri;


### PR DESCRIPTION
Since NLB has already pointed `www.ioha2020.sg` to our redirection server, we have to account for the case of `https://www.ioha2020.sg`. We don't usually care about the www subdomain since we usually point this to the KeyCDN zone alias, but since we want special redirection behavior, we have asked NLB to point `www.ioha2020.sg` to our redirection server instead of the KeyCDN zone alias.

As such, we need to add a server name to the ioha2021.gov.sg server block on the https redirect config. This works because the ioha 2021 SSL cert includes a DNS name for 'www.ioha2020.sg'.

**Other things that were done**
- remove zone alias for `www.ioha2020.sg`
- update SSL cert on KeyCDN