### PR TITLE
Re-org config, do not disclose nginx version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,16 @@ FROM nginx:1.18.0
 
 # Copy over nginx config files
 COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY ./https_www_redirects.conf /etc/nginx/https_www_redirects.conf
-COPY ./domain_redirects.conf /etc/nginx/domain_redirects.conf
+
+# Copy over redirecting configuration
+COPY ./https_www_redirects.conf /etc/nginx/conf.d/https_www_redirects.conf
+COPY ./domain_redirects.conf /etc/nginx/conf.d/domain_redirects.conf
+
+# Copy over config for fallback port 80 listener
+COPY ./fallback.conf /etc/nginx/conf.d/fallback.conf
+
+# Remove the default nginx config
+RUN rm -f /etc/nginx/conf.d/default.conf
 
 # Allow HTTP and HTTPS
 EXPOSE 80 443

--- a/fallback.conf
+++ b/fallback.conf
@@ -1,0 +1,7 @@
+# Adding a default_server config ensures that all requests on port 80 that do not match existing server_name blocks
+# will go to the following server directive:
+server {
+    listen  80 default_server;
+    listen  [::]:80 default_server;
+    return 301 https://www.$host$request_uri;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,7 @@ events {
 }
 
 http {
+	server_tokens off;
 
 	log_format main
 	    '$remote_addr '

--- a/nginx.conf
+++ b/nginx.conf
@@ -66,14 +66,9 @@ http {
 	# since TCP frames are filled up before being sent out. (adds TCP_CORK)
 	tcp_nopush      on;
 
-    include https_www_redirects.conf;
-    include domain_redirects.conf;
+    # Include feature-specific configuration found in conf.d
+    # This includes domain and https redirects as well as the 
+    # default server
+    include conf.d/*.conf;
 
-    # Adding a default_server config ensures that all requests on port 80 that do not match existing server_name blocks
-    # will go to the following server directive:
-    server {
-        listen  80 default_server;
-        listen  [::]:80 default_server;
-        return 301 https://www.$host$request_uri;
-    }
 }


### PR DESCRIPTION
This PR brings the organisation of our nginx config files in-line
with existing conventions, where nginx.conf will reference all files
in the `conf.d/` directory.

This also moves the default port 80 listener into its own config.
While not necessary, it will bring us further in-line with the config
that we will use in future once we use a Docker image that incorporates
certbot, so that we can support automatic provision and renewal of
LetsEncrypt certs.

Finally, we also turn `server_tokens` off so that we do not disclose exactly
what version of nginx we are using.

- Dockerfile: copy specific config into `conf.d/`
- nginx.conf: Shard out port 80 listener to its own config,
  include files in `conf.d/`
- turn `server_tokens` off to drop version numbers from our Servers header

Fixes #70 