### PR TITLE
Add EFS, certbot, test with Isomer subdomains

### DIFF
--- a/.ebextensions/mount-efs.config
+++ b/.ebextensions/mount-efs.config
@@ -1,0 +1,105 @@
+###################################################################################################
+#### Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file mounts an Amazon EFS file system to a directory named /efs. To mount
+#### the file system to a different path, modify the MOUNT_DIRECTORY value in the "option_settings"
+#### section.
+####
+#### The FILE_SYSTEM_ID setting references a resource named "FileSystem", which is created by the
+#### storage-efs-createfilesystem.config configuration file. To use this file to mount a
+#### file system that you created outside of AWS Elastic Beanstalk, replace the Ref with the
+#### resource ID (e.g., fs-e7605f4e):
+####
+####      FILE_SYSTEM_ID: fs-e7605f4e
+####
+#### If your environment and file system are in a custom VPC, you must configure the VPC to allow
+#### DNS resolution and DNS host names. See this topic in the VPC User Guide for more information:
+####    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html
+###################################################################################################
+
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    # Inject these from the Elastic Beanstalk environment directly
+    # FILE_SYSTEM_ID: '`{"Ref" : "FileSystem"}`'
+
+##############################################
+#### Do not modify values below this line ####
+##############################################
+    REGION: '`{"Ref": "AWS::Region"}`'
+
+packages:
+  yum:
+    nfs-utils: []
+
+commands:
+  01_mount:
+    command: "/tmp/mount-efs.sh"
+
+files:
+  "/tmp/mount-efs.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+
+        EFS_REGION=$(/opt/elasticbeanstalk/bin/get-config environment -k REGION)
+        EFS_MOUNT_DIR=/etc/letsencrypt
+        EFS_FILE_SYSTEM_ID=$(/opt/elasticbeanstalk/bin/get-config environment -k FILE_SYSTEM_ID)
+
+        echo "Mounting EFS filesystem ${EFS_DNS_NAME} to directory ${EFS_MOUNT_DIR} ..."
+
+        echo 'Stopping NFS ID Mapper...'
+        service rpcidmapd status &> /dev/null
+        if [ $? -ne 0 ] ; then
+            echo 'rpc.idmapd is already stopped!'
+        else
+            service rpcidmapd stop
+            if [ $? -ne 0 ] ; then
+                echo 'ERROR: Failed to stop NFS ID Mapper!'
+                exit 1
+            fi
+        fi
+
+        echo 'Checking if EFS mount directory exists...'
+        if [ ! -d ${EFS_MOUNT_DIR} ]; then
+            echo "Creating directory ${EFS_MOUNT_DIR} ..."
+            mkdir -p ${EFS_MOUNT_DIR}
+            if [ $? -ne 0 ]; then
+                echo 'ERROR: Directory creation failed!'
+                exit 1
+            fi
+        else
+            echo "Directory ${EFS_MOUNT_DIR} already exists!"
+        fi
+
+        mountpoint -q ${EFS_MOUNT_DIR}
+        if [ $? -ne 0 ]; then
+            echo "mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}"
+            mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}
+            if [ $? -ne 0 ] ; then
+                echo 'ERROR: Mount command failed!'
+                exit 1
+            fi
+            chmod 777 ${EFS_MOUNT_DIR}
+            runuser -l  ec2-user -c "touch ${EFS_MOUNT_DIR}/it_works"
+            if [[ $? -ne 0 ]]; then
+                echo 'ERROR: Permission Error!'
+                exit 1
+            else
+                runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
+            fi
+        else
+            echo "Directory ${EFS_MOUNT_DIR} is already a valid mountpoint!"
+        fi
+
+        echo 'EFS mount complete.'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
     - master
     - staging
+    - letsencrypt
 git:
   depth: 1
 script:
@@ -28,3 +29,13 @@ deploy:
     wait_until_deployed: true
     on:
       branch: staging
+  - provider: elasticbeanstalk
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: "ap-southeast-1"
+    app: "isomer-redirection"
+    env: "redirection-$TRAVIS_BRANCH"
+    bucket_name: "redirection-$TRAVIS_BRANCH"
+    wait_until_deployed: true
+    on:
+      branch: letsencrypt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.18.0
+FROM staticfloat/nginx-certbot@sha256:dc44e313c7a88df5cb4d7795d718f69a275d68ea4ca9b2fd8aa0984384bb7b90
 
 # Copy over nginx config files
 COPY ./nginx.conf /etc/nginx/nginx.conf
@@ -6,9 +6,6 @@ COPY ./nginx.conf /etc/nginx/nginx.conf
 # Copy over redirecting configuration
 COPY ./https_www_redirects.conf /etc/nginx/conf.d/https_www_redirects.conf
 COPY ./domain_redirects.conf /etc/nginx/conf.d/domain_redirects.conf
-
-# Copy over config for fallback port 80 listener
-COPY ./fallback.conf /etc/nginx/conf.d/fallback.conf
 
 # Remove the default nginx config
 RUN rm -f /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./https_www_redirects.conf /etc/nginx/conf.d/https_www_redirects.conf
 COPY ./domain_redirects.conf /etc/nginx/conf.d/domain_redirects.conf
 
+COPY ./letsencrypt /etc/nginx/user.conf.d
+
 # Remove the default nginx config
 RUN rm -f /etc/nginx/conf.d/default.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,9 @@ COPY ./domain_redirects.conf /etc/nginx/conf.d/domain_redirects.conf
 # Remove the default nginx config
 RUN rm -f /etc/nginx/conf.d/default.conf
 
+COPY ./entrypoint.sh /scripts/entrypoint.sh
+COPY ./poll_certbot.sh /scripts/poll_certbot.sh
+
 # Allow HTTP and HTTPS
 EXPOSE 80 443
+

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -12,6 +12,10 @@
     {
       "HostDirectory": "/home/ec2-user",
       "ContainerDirectory": "/ssl"
+    },
+    {
+      "HostDirectory": "/etc/letsencrypt",
+      "ContainerDirectory": "/etc/letsencrypt"
     }
   ],
   "Logging": "/var/log/nginx/"

--- a/LETSENCRYPT.md
+++ b/LETSENCRYPT.md
@@ -1,0 +1,74 @@
+## Isomer's Integration with LetsEncrypt
+
+### Introduction
+
+LetsEncrypt is a nonprofit Certificate Authority run by the Internet 
+Security Research Group (ISRG) that provides free SSL certificates.
+
+Isomer takes advantage of this through:
+
+- KeyCDN and Cloudflare's built-in integration for www and other
+  non-root domain names, and;
+- Using [certbot](https://certbot.eff.org) for root domain names
+  hosted by the redirection server.
+
+This document shall focus on the latter usecase.
+
+
+### Background and Motivations
+
+Isomer serves web traffic on `www.example.gov.sg`, and 301 redirects 
+requests to `example.gov.sg` to the www subdomain. These are served 
+over HTTPS by separate services, respectively, a CDN and an EC2 instance 
+(the redirection server).
+
+Historically, Isomer users were asked to provide an Extended Validation
+certificate for use on both services. Given that this is no longer needed,
+Isomer can make use of built-in LetsEncrypt certificate provisioning
+found on CDNs. 
+
+The redirection server also needs SSL certificates, and given that it
+accounts for less than 0.1% of web traffic coming to Isomer, it makes 
+very little sense to allocate resources to manually procure and install
+a certificate. Given that LetsEncrypt certificates are free and only
+available through automated means, integration with Isomer's redirection
+server makes sense.
+
+### Implementation Overview
+
+Eliot Saba (@staticfloat) maintains a Docker image based on nginx,
+which incorporates certbot. At runtime, the image runs:
+
+- a bootstrap script that inspects and disables/enables config at 
+  `/etc/nginx/user.conf.d/` and `/etc/nginx/conf.d/` if 
+  they reference missing SSL files before enabling nginx, and;
+
+- a long-running shell script that does the following both at the start 
+  as well once every week:
+
+  - run certbot to obtain certificates for domain names implied by
+    `ssl_certificate_key` if the path is of the form 
+    `/etc/letsencrypt/live/<domain.gov.sg>/privkey.pem` and the file
+    is either missing or expired, and;
+
+  - enable the config once the certificates are obtained by reloading
+    nginx, through the use of `kill -HUP`.
+
+The contact e-mail for these certificates is configured by the env var
+`CERTBOT_EMAIL`.
+
+Certifcates are stored in an AWS Elastic File System mounted into the EC2
+instance at `/etc/letsencrypt`.
+
+Nginx has been configured to reroute requests for `/.well-known` on port 80 
+to certbot's internal web service. This allows certbot to prove to LetsEncrypt
+that Isomer has control of the domain that we are requesting a certificate for,
+via an [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/).
+
+Custom SSL certificates are still supported by adding nginx server config blocks
+to `https_www_redirects.conf`
+
+### Further Reading
+
+Further information can be found at the relevant GitHub 
+[repository](https://github.com/staticfloat/docker-nginx-certbot).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,28 @@ The redirection service is an NGINX server that does the following three things:
 - Redirect requests for **HTTPS apex** domains to **HTTPS www** domains, e.g. `https://example.gov.sg` to `https://www.example.gov.sg`
 - Redirect requests for **custom HTTP** domains to **custom HTTPS** domains, e.g. `http://custom-example.gov.sg` to `https://example.gov.sg`
 
-### How to configure
+### How to configure - LetsEncrypt
+
+Create the following file named `<example.gov.sg>.conf` under the `letsencrypt/` directory:
+
+```
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     <example.gov.sg>;
+    ssl_certificate /etc/letsencrypt/live/<example.gov.sg>/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/<example.gov.sg>/privkey.pem;
+    return          301 https://www.<example.gov.sg>$request_uri;
+}
+
+```
+
+The files referred to in `ssl_certificate` and `ssl_certificate_key` will not exist; these will
+be created by [certbot](https://certbot.eff.org).
+
+Further information on Isomer's LetsEncrypt integration can be found [here](/LETSENCRYPT.md).
+
+### How to configure - custom certificates
 
 #### SSL redirection from https://example.gov.sg to https://www.example.gov.sg
 
@@ -36,6 +57,7 @@ Next, modify the `https_www_redirects.conf` file to include the new SSL block fo
 ```
 server {
   listen         443 ssl http2;
+  listen         [::]:443 ssl http2;
   server_name   <example.gov.sg>;
   ssl_certificate /ssl/<example.gov.sg>.crt; 
   ssl_certificate_key /ssl/<example.gov.sg>.key;

--- a/domain_redirects.conf
+++ b/domain_redirects.conf
@@ -29,7 +29,7 @@ server {
 }
 
 server {
-        server_name     isomer.gov.sg *.isomer.gov.sg;
+        server_name     isomer.gov.sg;
         return 301 https://www.isomer.gov.sg/;
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# When we get killed, kill all our children
+trap "exit" INT TERM
+trap "kill 0" EXIT
+
+# Source in util.sh so we can have our nice tools
+. $(cd $(dirname $0); pwd)/util.sh
+
+# first include any user configs if they've been mounted
+template_user_configs
+
+# Immediately run auto_enable_configs so that nginx is in a runnable state
+auto_enable_configs
+
+# Start up nginx, save PID so we can reload config inside of run_certbot.sh
+nginx -g "daemon off;" &
+NGINX_PID=$!
+
+# Lastly, run startup scripts
+for f in /scripts/startup/*.sh; do
+    if [ -x "$f" ]; then
+        echo "Running startup script $f"
+        $f
+    fi
+done
+echo "Done with startup"
+
+(echo "Waiting for 10 seconds before starting poller" && sleep 10 && /scripts/poll_certbot.sh $NGINX_PID) &
+POLL_PID=$!
+
+# Wait for nginx
+wait -n "$NGINX_PID"

--- a/fallback.conf
+++ b/fallback.conf
@@ -1,7 +1,0 @@
-# Adding a default_server config ensures that all requests on port 80 that do not match existing server_name blocks
-# will go to the following server directive:
-server {
-    listen  80 default_server;
-    listen  [::]:80 default_server;
-    return 301 https://www.$host$request_uri;
-}

--- a/letsencrypt/letsencrypt-again.isomer.gov.sg.conf
+++ b/letsencrypt/letsencrypt-again.isomer.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     letsencrypt-again.isomer.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/letsencrypt-again.isomer.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/letsencrypt-again.isomer.gov.sg/privkey.pem;
+    return          301 https://www.isomer.gov.sg$request_uri;
+}

--- a/letsencrypt/letsencrypt-test.isomer.gov.sg.conf
+++ b/letsencrypt/letsencrypt-test.isomer.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     letsencrypt-test.isomer.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/letsencrypt-test.isomer.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/letsencrypt-test.isomer.gov.sg/privkey.pem;
+    return          301 https://www.isomer.gov.sg$request_uri;
+}

--- a/poll_certbot.sh
+++ b/poll_certbot.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+NGINX_PID=$1
+
+# Instead of trying to run `cron` or something like that, just sleep and run `certbot`.
+while [ true ]; do
+    # Make sure we do not run container empty (without nginx process).
+    # If nginx quit for whatever reason then stop the container.
+    # Leave the restart decision to the container orchestration.
+    if ! ps aux | grep --quiet [n]ginx ; then
+        exit 1
+    fi
+
+    # Run certbot, tell nginx to reload its config
+    echo "Run certbot"
+    /scripts/run_certbot.sh
+    kill -HUP $NGINX_PID
+
+    # Sleep for 1 week
+    sleep 604810 &
+    SLEEP_PID=$!
+
+    # Wait for 1 week sleep or nginx
+    wait -n "$SLEEP_PID" "$NGINX_PID"
+done


### PR DESCRIPTION
## Problem

While our CDN supports LetsEncrypt certs out-of-the-box, our redirection server currently does not,
so certs still have to be purchased and installed manually for Isomer sites. Given that most browsers automatically
transform addresses from the root domain to the www subdomain and intelligently pick between http and https, server-side redirection accounts for a tiny portion of web traffic served across Isomer's infrastructure. 

The time and funds spent procuring the certificates for redirection is hence disproportionate, and a cheaper and more automated approach should be considered.

Closes #73 
Closes #72 

## Solution

- Use `staticfloat/nginx-certbot`, a Docker image that contains nginx as well as certbot, 
  the EFF's tool for automatically provisioning LetsEncrypt certs
  - Override the image's built-in scripts to appease Elastic Beanstalk
- Have the certs stashed in Elastic File System so that they persist even if EC2 instances get terminated
  - S3 was originally considered, but was found to be unreliable for persisting writes made by EC2.
  - A workaround to make the write process more reliable is to install the AWS CLI and write to S3 using the CLI, but this was found to be unwieldy
- Configure letsencrypt-test.isomer.gov.sg and letsencrypt-again.isomer.gov.sg by following instructions provided [here](https://github.com/staticfloat/docker-nginx-certbot)

## Verification
See Qualys SSL Labs report [here](https://www.ssllabs.com/ssltest/analyze.html?d=letsencrypt-again.isomer.gov.sg)

## Notes
- letsencrypt-again was created because the number of duplicate certs requested for letsencrypt-test was exceeded for the week.
- Once merged, the commit that configures Travis for the letsencrypt test environment will be reverted.
