### PR TITLE
Add www.jobsgohere.gov.sg

### DIFF
--- a/letsencrypt/www.jobsgohere.gov.sg.conf
+++ b/letsencrypt/www.jobsgohere.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     www.jobsgohere.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/www.jobsgohere.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/www.jobsgohere.gov.sg/privkey.pem;
+    return          301 https://www.gov.sg/features/jobs-go-here;
+}


### PR DESCRIPTION
Redirect any requests to the domain to the corresponding gov.sg microsite, ignoring $request_uri

Follow up to #92 