### PR TITLE
vapt: create ask.gov.sg.conf

### DIFF
--- a/letsencrypt/ask.gov.sg.conf
+++ b/letsencrypt/ask.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     ask.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/ask.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/ask.gov.sg/privkey.pem;
+    return          301 https://www.ask.gov.sg$request_uri;
+}


### PR DESCRIPTION
This PR sets up a redirection file to redirect for the following:
- http(s)://ask.gov.sg to https://www.ask.gov.sg

To note that the following VAPT configurations to be tested are already present:
- http(s)://letsencrypt-test.isomer.gov.sg to https://www.isomer.gov.sg
- http(s)://letsencrypt-again.isomer.gov.sg to https://www.isomer.gov.sg (with SAN)