### PR TITLE
Update safetyatseaweek.gov.sg.conf

### DIFF
--- a/letsencrypt/safetyatseaweek.gov.sg.conf
+++ b/letsencrypt/safetyatseaweek.gov.sg.conf
@@ -1,7 +1,7 @@
 server {
     listen          443 ssl http2;
     listen          [::]:443 ssl http2;
-    server_name     safetyatseaweek.gov.sg www.safetyatseaweek.gov.sg;
+    server_name     safetyatseaweek.gov.sg;
     ssl_certificate /etc/letsencrypt/live/safetyatseaweek.gov.sg/fullchain.pem;
     ssl_certificate_key     /etc/letsencrypt/live/safetyatseaweek.gov.sg/privkey.pem;
     return          301 https://www.safetyatseaweek.gov.sg$request_uri;


### PR DESCRIPTION
This PR removes the extra `www.safetyatseaweek.gov.sg` from the `server_name` field. Our request to letsencrypt failed because the DNS record for `www.safetyatseaweek.gov.sg` is not pointed at the redirection service.