### PR TITLE
Vapt/revert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           ref = os.environ['GITHUB_REF']
           prod = os.environ['PRODUCTION_BRANCH']
           staging = os.environ['STAGING_BRANCH']
-          if ref == prod:
+          if ref == prod or ref == staging:
             print('::set-output name=proceed::true')
           else:
             print('::set-output name=proceed::false')

--- a/letsencrypt/letsencrypt-test.isomer.gov.sg.conf
+++ b/letsencrypt/letsencrypt-test.isomer.gov.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen          443 ssl http2;
-    listen          [::]:443 ssl http2;
-    server_name     letsencrypt-test.isomer.gov.sg letsencrypt-again.isomer.gov.sg;
-    ssl_certificate /etc/letsencrypt/live/letsencrypt-test.isomer.gov.sg/fullchain.pem;
-    ssl_certificate_key     /etc/letsencrypt/live/letsencrypt-test.isomer.gov.sg/privkey.pem;
-    return          301 https://www.isomer.gov.sg$request_uri;
-}


### PR DESCRIPTION
This PR reverts the changes made to `isomer-redirection` for VAPT:
- Reenables .github deploy actions on the staging branch
- Removes letsencrypt-test.isomer.gov.sg and letsencrypt-again.isomer.gov.sg redirection to isomer.gov.sg