### PR TITLE
feat: update ssl session configs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -44,8 +44,8 @@ http {
     # HSTS
     add_header Strict-Transport-Security "max-age=63072000" always;
 
-    ssl_session_timeout 1h;
-    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+    ssl_session_timeout 4h;
+    ssl_session_cache shared:MozSSL:20m;  # about 80000 sessions
     ssl_session_tickets off;
 
     # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam.pem


### PR DESCRIPTION
We have been getting more of the following errors:

`could not allocate new session in SSL session shared cache "MozSSL" while SSL handshaking`

This indicates that our session cache does not have enough space.

To remedy this, we are going to:
- increase the `ssl_session_timeout` (increasing the amount of time
for which we can reuse a session)
- `increase the ssl_session_cache size`

The new values were obtained from an example given in the nginx docs:
https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-tcp/

This is a follow up to commit `b1096b7`.