### PR TITLE
refactor: get S3 bucket as an env var

### DIFF
--- a/.ebextensions/download-ssl-files.config
+++ b/.ebextensions/download-ssl-files.config
@@ -1,3 +1,3 @@
 commands:
   01_get_ssl_files:
-    command: aws s3 cp s3://isomer-ssl-clone/ /home/ec2-user --recursive
+    command: aws s3 cp s3://$(/opt/elasticbeanstalk/bin/get-config environment -k SSL_BUCKET_NAME)/ /home/ec2-user --recursive


### PR DESCRIPTION
This PR hides the name of the S3 bucket from which we get our SSL certs as an environment variable.

## Deploy notes
- [x] Update env vars for staging environment

When merging to master:
- [ ] Update env vars for master environment