### PR TITLE
ci: update staging eb env name to redirection-staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
   STAGING_BRANCH: refs/heads/staging
   EB_APP: isomer-redirection
   EB_ENV_PRODUCTION: redir-master
-  EB_ENV_STAGING: redir-staging
+  EB_ENV_STAGING: redirection-staging
 jobs:
   gatekeep:
     name: Determine if Build & Deploy is needed


### PR DESCRIPTION
This PR updates the staging AWS EB environment name to the new `redirection-staging`. The new EB environment lives in the staging VPC and is connected to a new EFS instance (which also lives in the staging VPC)