### PR TITLE
Redirection for e-commercepartnership.digitalworkplace.gov.sg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
   STAGING_BRANCH: refs/heads/staging
   EB_APP: isomer-redirection
   EB_ENV_PRODUCTION: redir-master
-  EB_ENV_STAGING: redir-staging
+  EB_ENV_STAGING: redirection-staging
 jobs:
   gatekeep:
     name: Determine if Build & Deploy is needed

--- a/http_domain_redirects.conf
+++ b/http_domain_redirects.conf
@@ -69,11 +69,6 @@ server {
 }
 
 server {
-        server_name     ioha2020.sg *.ioha2020.sg;
-        return 301 https://www.ioha2021.gov.sg;
-}
-
-server {
         server_name     safetravel.gov.sg *.safetravel.gov.sg;
         return 301 https://safetravel.ica.gov.sg;
 }

--- a/https_www_redirects/aperforum.org.conf
+++ b/https_www_redirects/aperforum.org.conf
@@ -1,8 +1,0 @@
-server {
-    listen          443 ssl http2;
-    listen          [::]:443 ssl http2;
-    server_name     aperforum.org;
-    ssl_certificate /ssl/aperforum.org.crt;
-    ssl_certificate_key     /ssl/aperforum.org.key;
-    return          301 https://www.aperforum.org$request_uri;
-}

--- a/https_www_redirects/eyeonasia.gov.sg.conf
+++ b/https_www_redirects/eyeonasia.gov.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen         443 ssl http2;
-    listen         [::]:443 ssl http2;
-    server_name    eyeonasia.gov.sg;
-    ssl_certificate /ssl/eyeonasia.gov.sg.crt; 
-    ssl_certificate_key /ssl/eyeonasia.gov.sg.key;
-    return         301 https://www.eyeonasia.gov.sg$request_uri;
-}

--- a/https_www_redirects/eyeonasia.sg.conf
+++ b/https_www_redirects/eyeonasia.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen         443 ssl http2;
-    listen         [::]:443 ssl http2;
-    server_name    eyeonasia.sg www.eyeonasia.sg;
-    ssl_certificate /ssl/www.eyeonasia.sg.crt; 
-    ssl_certificate_key /ssl/www.eyeonasia.sg.key;
-    return         301 https://www.eyeonasia.gov.sg$request_uri;
-}

--- a/https_www_redirects/ioha2021.gov.sg.conf
+++ b/https_www_redirects/ioha2021.gov.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen          443 ssl http2;
-    listen          [::]:443 ssl http2;
-    server_name     ioha2021.gov.sg www.ioha2020.sg;
-    ssl_certificate /ssl/www.ioha2021.gov.sg.crt;
-    ssl_certificate_key     /ssl/www.ioha2021.gov.sg.key;
-    return          301 https://www.ioha2021.gov.sg$request_uri;
-}

--- a/https_www_redirects/nationalreadingmovement.sg.conf
+++ b/https_www_redirects/nationalreadingmovement.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen         443 ssl http2;
-    listen         [::]:443 ssl http2;
-    server_name    nationalreadingmovement.sg;
-    ssl_certificate /ssl/www.nationalreadingmovement.sg.crt; 
-    ssl_certificate_key /ssl/www.nationalreadingmovement.sg.key;
-    return         301 https://www.nationalreadingmovement.sg$request_uri;
-}

--- a/letsencrypt/aperforum.org.conf
+++ b/letsencrypt/aperforum.org.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     aperforum.org;
+    ssl_certificate /etc/letsencrypt/live/aperforum.org/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/aperforum.org/privkey.pem;
+    return          301 https://www.aperforum.org$request_uri;
+}

--- a/letsencrypt/eyeonasia.gov.sg.conf
+++ b/letsencrypt/eyeonasia.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     eyeonasia.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/eyeonasia.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/eyeonasia.gov.sg/privkey.pem;
+    return          301 https://www.eyeonasia.gov.sg$request_uri;
+}

--- a/letsencrypt/ioha2021.gov.sg.conf
+++ b/letsencrypt/ioha2021.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     ioha2021.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/ioha2021.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/ioha2021.gov.sg/privkey.pem;
+    return          301 https://www.ioha2021.gov.sg$request_uri;
+}

--- a/letsencrypt/nationalreadingmovement.sg.conf
+++ b/letsencrypt/nationalreadingmovement.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     nationalreadingmovement.sg;
+    ssl_certificate /etc/letsencrypt/live/nationalreadingmovement.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/nationalreadingmovement.sg/privkey.pem;
+    return          301 https://www.nationalreadingmovement.sg$request_uri;
+}

--- a/letsencrypt/quickbuy.gov.sg.conf
+++ b/letsencrypt/quickbuy.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     e-commercepartnership.digitalworkplace.gov.sg quickbuy.gov.sg;
+    ssl_certificate /etc/letsencrypt/live/quickbuy.gov.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/quickbuy.gov.sg/privkey.pem;
+    return          301 https://www.quickbuy.gov.sg$request_uri;
+}

--- a/letsencrypt/quickbuy.gov.sg.conf
+++ b/letsencrypt/quickbuy.gov.sg.conf
@@ -1,7 +1,7 @@
 server {
     listen          443 ssl http2;
     listen          [::]:443 ssl http2;
-    server_name     e-commercepartnership.digitalworkplace.gov.sg quickbuy.gov.sg;
+    server_name     quickbuy.gov.sg;
     ssl_certificate /etc/letsencrypt/live/quickbuy.gov.sg/fullchain.pem;
     ssl_certificate_key     /etc/letsencrypt/live/quickbuy.gov.sg/privkey.pem;
     return          301 https://www.quickbuy.gov.sg$request_uri;


### PR DESCRIPTION
redirecting old site e-commercepartnership.digitalworkplace.gov.sg to www.quickbuy.gov.sg (also removing e-commercepartnership.digitalworkplace.gov.sg domain as no longer active and needed for redirection)

SSL cert switch to letsencrypt for eyeonasia.gov.sg, ioha2021.gov.sg, nationalreadingmovement.sg and aperforum.org