### PR TITLE
feat: update ssl session config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -44,8 +44,8 @@ http {
     # HSTS
     add_header Strict-Transport-Security "max-age=63072000" always;
 
-    ssl_session_timeout 4h;
-    ssl_session_cache shared:MozSSL:20m;  # about 80000 sessions
+    ssl_session_timeout 2h;
+    ssl_session_cache shared:MozSSL:40m;  # about 160000 sessions
     ssl_session_tickets off;
 
     # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam.pem


### PR DESCRIPTION
We have recently been seeing an uptick of the following error again:

`could not allocate new session in SSL session shared cache "MozSSL" while SSL handshaking`

This error seems to result from the cache being full, and nginx not being able to free enough space by removing a least recently used session (see [here](https://trac.nginx.org/nginx/ticket/621)). The suggested solution would be to use smaller session timeouts or a larger shared memory zone to avoid cache overflows - this PR does both, although the smaller cache time may affect performance slightly because reusing cached session parameters reduces the number of time-consuming handshakes. We could alternatively only increase the cache size.