### PR TITLE
Redirect sgeco to MSE page

### DIFF
--- a/letsencrypt/sgeco.gov.sg.conf
+++ b/letsencrypt/sgeco.gov.sg.conf
@@ -1,8 +1,8 @@
 server {
     listen          443 ssl http2;
     listen          [::]:443 ssl http2;
-    server_name     sgeco.gov.sg;
+    server_name     sgeco.gov.sg www.sgeco.gov.sg;
     ssl_certificate /etc/letsencrypt/live/sgeco.gov.sg/fullchain.pem;
     ssl_certificate_key     /etc/letsencrypt/live/sgeco.gov.sg/privkey.pem;
-    return          301 https://www.sgeco.gov.sg$request_uri;
+    return          301 https://www.mse.gov.sg/sgecofund;
 }


### PR DESCRIPTION
Point sgeco to a dedicated page that MSE has set up on their corp site