### PR TITLE
Map languagecouncils.sg/$council to subdomain

### DIFF
--- a/letsencrypt/languagecouncils.sg.conf
+++ b/letsencrypt/languagecouncils.sg.conf
@@ -1,0 +1,15 @@
+server {
+    listen          443 ssl http2;
+    listen          [::]:443 ssl http2;
+    server_name     languagecouncils.sg www.languagecouncils.sg;
+    ssl_certificate /etc/letsencrypt/live/languagecouncils.sg/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/languagecouncils.sg/privkey.pem;
+
+    location ~ ^/(?<council>goodenglish|mbms|mandarin|tamil)/ {
+        rewrite         ^/goodenglish|mbms|mandarin|tamil/(.*) /$1 break;
+        return          301 https://$council.languagecouncils.sg$uri;
+    }
+    location / {
+        return          301 https://www.nhb.gov.sg/What-We-Do/Our-Work/Community-Engagement/Public-Programmes/Nationwide-Language-Campaigns;
+    }
+}


### PR DESCRIPTION
To support a possible migration made by NHB to move the
language councils microsites from specific paths on 
languagecouncils.sg to specific subdomains, configure 
isomer-redirection to handle traffic from languagecouncils.sg.

- map requests to legacy path-based urls for the language councils
  to subdomain equivalents
- map all other requests to a specific page for NHB