### PR TITLE
Delete siot.gov.sg.conf

### DIFF
--- a/letsencrypt/siot.gov.sg.conf
+++ b/letsencrypt/siot.gov.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen          443 ssl http2;
-    listen          [::]:443 ssl http2;
-    server_name     siot.gov.sg;
-    ssl_certificate /etc/letsencrypt/live/siot.gov.sg/fullchain.pem;
-    ssl_certificate_key     /etc/letsencrypt/live/siot.gov.sg/privkey.pem;
-    return          301 https://www.siot.gov.sg$request_uri;
-}


### PR DESCRIPTION
No longer an Isomer site, they have also pointed their DNS away from us.