### PR TITLE
Partial site launch

### DIFF
--- a/letsencrypt/aps.edu.sg.conf
+++ b/letsencrypt/aps.edu.sg.conf
@@ -4,5 +4,5 @@ server {
       server_name     aps.edu.sg;
       ssl_certificate /etc/letsencrypt/live/aps.edu.sg/fullchain.pem;
       ssl_certificate_key     /etc/letsencrypt/live/aps.edu.sg/privkey.pem;
-      return          301 https://www.aps.moe.edu.sg$request_uri;
+      return          301 https://www.aps.edu.sg$request_uri;
   }

--- a/letsencrypt/nushigh.edu.sg.conf
+++ b/letsencrypt/nushigh.edu.sg.conf
@@ -4,5 +4,5 @@ server {
       server_name     nushigh.edu.sg;
       ssl_certificate /etc/letsencrypt/live/nushigh.edu.sg/fullchain.pem;
       ssl_certificate_key     /etc/letsencrypt/live/nushigh.edu.sg/privkey.pem;
-      return          301 https://nushigh.edu.sg$request_uri;
+      return          301 https://www.nushigh.edu.sg$request_uri;
   }

--- a/letsencrypt/nushigh.edu.sg.conf
+++ b/letsencrypt/nushigh.edu.sg.conf
@@ -1,0 +1,8 @@
+server {
+      listen          443 ssl http2;
+      listen          [::]:443 ssl http2;
+      server_name     nushigh.edu.sg;
+      ssl_certificate /etc/letsencrypt/live/nushigh.edu.sg/fullchain.pem;
+      ssl_certificate_key     /etc/letsencrypt/live/nushigh.edu.sg/privkey.pem;
+      return          301 https://nushigh.edu.sg$request_uri;
+  }

--- a/letsencrypt/qifapri.moe.edu.sg.conf
+++ b/letsencrypt/qifapri.moe.edu.sg.conf
@@ -4,5 +4,5 @@ server {
       server_name     qifapri.moe.edu.sg;
       ssl_certificate /etc/letsencrypt/live/qifapri.moe.edu.sg/fullchain.pem;
       ssl_certificate_key     /etc/letsencrypt/live/qifapri.moe.edu.sg/privkey.pem;
-      return          301 https://qifapri.moe.edu.sg$request_uri;
+      return          301 https://www.qifapri.moe.edu.sg$request_uri;
   }

--- a/letsencrypt/qifapri.moe.edu.sg.conf
+++ b/letsencrypt/qifapri.moe.edu.sg.conf
@@ -1,0 +1,8 @@
+server {
+      listen          443 ssl http2;
+      listen          [::]:443 ssl http2;
+      server_name     qifapri.moe.edu.sg;
+      ssl_certificate /etc/letsencrypt/live/qifapri.moe.edu.sg/fullchain.pem;
+      ssl_certificate_key     /etc/letsencrypt/live/qifapri.moe.edu.sg/privkey.pem;
+      return          301 https://qifapri.moe.edu.sg$request_uri;
+  }


### PR DESCRIPTION
Need to push in the .conf file due to the special configuration of NUS high domain. 

Current assumption is that it should work, but pushing this asap so that in the event of failure, this is still rectifiable. 
This operation is safe as the other schools are already pointing to redir server 
