### PR TITLE
Redirection clean-up 08/12/23

### DIFF
--- a/letsencrypt/ctrlshift.gov.sg.conf
+++ b/letsencrypt/ctrlshift.gov.sg.conf
@@ -1,7 +1,7 @@
 server {
     listen          443 ssl http2;
     listen          [::]:443 ssl http2;
-    server_name     ctrlshift.gov.sg stewhatsnext.gov.sg www.stewhatsnext.gov.sg;
+    server_name     ctrlshift.gov.sg;
     ssl_certificate /etc/letsencrypt/live/ctrlshift.gov.sg/fullchain.pem;
     ssl_certificate_key     /etc/letsencrypt/live/ctrlshift.gov.sg/privkey.pem;
     return          301 https://www.ctrlshift.gov.sg$request_uri;

--- a/letsencrypt/healthinfo.gov.sg.conf
+++ b/letsencrypt/healthinfo.gov.sg.conf
@@ -1,0 +1,8 @@
+server {
+      listen          443 ssl http2;
+      listen          [::]:443 ssl http2;
+      server_name     healthinfo.gov.sg;
+      ssl_certificate /etc/letsencrypt/live/healthinfo.gov.sg/fullchain.pem;
+      ssl_certificate_key     /etc/letsencrypt/live/healthinfo.gov.sg/privkey.pem;
+      return          301 https://www.healthinfo.gov.sg$request_uri;
+  }

--- a/letsencrypt/supplyally.gov.sg.conf
+++ b/letsencrypt/supplyally.gov.sg.conf
@@ -1,8 +1,0 @@
-server {
-    listen          443 ssl http2;
-    listen          [::]:443 ssl http2;
-    server_name     supplyally.gov.sg sally.gov.sg www.sally.gov.sg;
-    ssl_certificate /etc/letsencrypt/live/supplyally.gov.sg/fullchain.pem;
-    ssl_certificate_key     /etc/letsencrypt/live/supplyally.gov.sg/privkey.pem;
-    return          301 https://www.supplyally.gov.sg$request_uri;
-}


### PR DESCRIPTION
ctrlshift.gov.sg.conf -> domains removed as they've been decommed. 
supplyally.gov.sg.conf -> all domains are already captured in supply.gov.sg 